### PR TITLE
feat: migrate to @myparcel-dev scope

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,4 +23,4 @@ jobs:
         with:
           token: ${{ secrets.GH_REPO_TOKEN }}
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN_NEW }}

--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@ Generates a readme.txt for WordPress plugin releases.
 ### With Yarn
 
 ```shell
-yarn add -D @myparcel/semantic-release-wordpress-readme-generator
+yarn add -D @myparcel-dev/semantic-release-wordpress-readme-generator
 ```
 
 ### With PNPM
 
 ```shell
-pnpm add -D @myparcel/semantic-release-wordpress-readme-generator
+pnpm add -D @myparcel-dev/semantic-release-wordpress-readme-generator
 ```
 
 ### With NPM
 
 ```shell
-npm install --save-dev @myparcel/semantic-release-wordpress-readme-generator
+npm install --save-dev @myparcel-dev/semantic-release-wordpress-readme-generator
 ```
 
 ## Usage
@@ -27,12 +27,12 @@ npm install --save-dev @myparcel/semantic-release-wordpress-readme-generator
 Add the following to your `release.config.js`, below the `@semantic-release/changelog` plugin:
 
 ```js
-const wordpressReadme = require('@myparcel/semantic-release-wordpress-readme-generator');
+const wordpressReadme = require('@myparcel-dev/semantic-release-wordpress-readme-generator');
 
 module.exports = {
   plugins: [
     // ...
-    '@myparcel/semantic-release-wordpress-readme-generator',
+    '@myparcel-dev/semantic-release-wordpress-readme-generator',
   ],
 };
 ```
@@ -51,13 +51,13 @@ By default, this is the configuration that will be used. This defines which comm
 To customize this, pass an object to the plugin and override the `types` property:
 
 ```js
-const wordpressReadme = require('@myparcel/semantic-release-wordpress-readme-generator');
+const wordpressReadme = require('@myparcel-dev/semantic-release-wordpress-readme-generator');
 
 module.exports = {
   plugins: [
     // ...
     [
-      '@myparcel/semantic-release-wordpress-readme-generator',
+      '@myparcel-dev/semantic-release-wordpress-readme-generator',
       {
         types: [
           {

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "debug": "^4.0.0"
   },
   "devDependencies": {
+    "@myparcel-dev/semantic-release-config": "^6.0.0",
     "@myparcel-eslint/eslint-config-esnext": "^1.2.0",
     "@myparcel-eslint/eslint-config-node": "^1.2.0",
     "@myparcel-eslint/eslint-config-prettier": "^1.2.0",
-    "@myparcel-dev/semantic-release-config": "^6.0.0",
     "eslint": "^8.38.0",
     "husky": "^8.0.1",
     "is-ci": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@myparcel/semantic-release-wordpress-readme-generator",
-  "version": "1.2.0",
+  "name": "@myparcel-dev/semantic-release-wordpress-readme-generator",
+  "version": "2.0.0",
   "description": "Generates a readme.txt for use with WordPress plugin releases in semantic-release",
   "repository": {
     "type": "git",
@@ -21,9 +21,9 @@
     "package.json": "npx sort-package-json",
     "*.js": "npx eslint --fix"
   },
-  "prettier": "@myparcel/prettier-config",
+  "prettier": "@myparcel-dev/prettier-config",
   "release": {
-    "extends": "@myparcel/semantic-release-config/github-npm"
+    "extends": "@myparcel-dev/semantic-release-config/github-npm"
   },
   "dependencies": {
     "debug": "^4.0.0"
@@ -32,7 +32,7 @@
     "@myparcel-eslint/eslint-config-esnext": "^1.2.0",
     "@myparcel-eslint/eslint-config-node": "^1.2.0",
     "@myparcel-eslint/eslint-config-prettier": "^1.2.0",
-    "@myparcel/semantic-release-config": "^5.0.0",
+    "@myparcel-dev/semantic-release-config": "^6.0.0",
     "eslint": "^8.38.0",
     "husky": "^8.0.1",
     "is-ci": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,6 +292,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@myparcel-dev/semantic-release-config@npm:^6.0.0":
+  version: 6.0.3
+  resolution: "@myparcel-dev/semantic-release-config@npm:6.0.3"
+  dependencies:
+    "@iwavesmedia/semantic-release-composer": ^1.0.0
+    "@semantic-release/changelog": ^6.0.1
+    "@semantic-release/commit-analyzer": ^9.0.2
+    "@semantic-release/exec": ^6.0.3
+    "@semantic-release/git": ^10.0.1
+    "@semantic-release/github": ^8.0.4
+    "@semantic-release/npm": ^10.0.0
+    "@semantic-release/release-notes-generator": ^10.0.0
+    conventional-changelog-conventionalcommits: ^4.0.0 || ^5.0.0
+    semantic-release: ^21.0.0
+  checksum: 757f7b6d2ec0afa638fed533040d9877b177956337bf734b681b17fb7db6d3510079a990642c109d6988e56c2bea56a4626978617e2677e21def37b9dd9e61b7
+  languageName: node
+  linkType: hard
+
+"@myparcel-dev/semantic-release-wordpress-readme-generator@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "@myparcel-dev/semantic-release-wordpress-readme-generator@workspace:."
+  dependencies:
+    "@myparcel-dev/semantic-release-config": ^6.0.0
+    "@myparcel-eslint/eslint-config-esnext": ^1.2.0
+    "@myparcel-eslint/eslint-config-node": ^1.2.0
+    "@myparcel-eslint/eslint-config-prettier": ^1.2.0
+    debug: ^4.0.0
+    eslint: ^8.38.0
+    husky: ^8.0.1
+    is-ci: ^3.0.1
+    lint-staged: ^13.0.3
+    prettier: ^2.7.1
+    semantic-release: ^21.0.0
+    vite: ^4.0.0
+  peerDependencies:
+    semantic-release: ^19 || ^20 || ^21
+  languageName: unknown
+  linkType: soft
+
 "@myparcel-eslint/eslint-config-es6@npm:^1.2.3":
   version: 1.2.3
   resolution: "@myparcel-eslint/eslint-config-es6@npm:1.2.3"
@@ -354,45 +393,6 @@ __metadata:
   checksum: c10890fdd77cd630500b65301dd43fe32ea82a383fdf51d64300744325210e9c4e4b80b6f274c761f7beabb21e128f54ea52955132de8fbe5c5d92aaa3baa3c1
   languageName: node
   linkType: hard
-
-"@myparcel/semantic-release-config@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@myparcel/semantic-release-config@npm:5.0.0"
-  dependencies:
-    "@iwavesmedia/semantic-release-composer": ^1.0.0
-    "@semantic-release/changelog": ^6.0.1
-    "@semantic-release/commit-analyzer": ^9.0.2
-    "@semantic-release/exec": ^6.0.3
-    "@semantic-release/git": ^10.0.1
-    "@semantic-release/github": ^8.0.4
-    "@semantic-release/npm": ^10.0.0
-    "@semantic-release/release-notes-generator": ^10.0.0
-    conventional-changelog-conventionalcommits: ^4.0.0 || ^5.0.0
-    semantic-release: ^21.0.0
-  checksum: 53161091a58b27e224f6a110fc196c56c7ebc28745a6ea49358eed2f4b091ac08d2472d46b927de72c8d74c681520289b4c159da909aa777b6c5801b79e5513c
-  languageName: node
-  linkType: hard
-
-"@myparcel/semantic-release-wordpress-readme-generator@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "@myparcel/semantic-release-wordpress-readme-generator@workspace:."
-  dependencies:
-    "@myparcel-eslint/eslint-config-esnext": ^1.2.0
-    "@myparcel-eslint/eslint-config-node": ^1.2.0
-    "@myparcel-eslint/eslint-config-prettier": ^1.2.0
-    "@myparcel/semantic-release-config": ^5.0.0
-    debug: ^4.0.0
-    eslint: ^8.38.0
-    husky: ^8.0.1
-    is-ci: ^3.0.1
-    lint-staged: ^13.0.3
-    prettier: ^2.7.1
-    semantic-release: ^21.0.0
-    vite: ^4.0.0
-  peerDependencies:
-    semantic-release: ^19 || ^20 || ^21
-  languageName: unknown
-  linkType: soft
 
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5


### PR DESCRIPTION
Migrates package from `@myparcel/semantic-release-wordpress-readme-generator` to `@myparcel-dev/semantic-release-wordpress-readme-generator`.

**Changes:**
- Update package name and bump to v2.0.0 (breaking change)
- Update dependencies: prettier-config and semantic-release-config to @myparcel-dev scope
- Update workflow to use NPM_TOKEN_NEW secret
- Update README with new package name